### PR TITLE
[#34] Anchor id 값 생성 로직에 다국어 문자 처리 기능 추가

### DIFF
--- a/src/utilities/markdown.js
+++ b/src/utilities/markdown.js
@@ -32,7 +32,8 @@ module.exports = function() {
     if (/-with-links/.test(lang)) {
       linksEnabled = true;
       lang = lang.replace(/-with-links/, "");
-    } 
+    }
+
     if (/-with-details/.test(lang)) {
       detailsEnabled = true;
       lang = lang.replace(/-with-details/, "");

--- a/src/utilities/markdown.js
+++ b/src/utilities/markdown.js
@@ -32,8 +32,7 @@ module.exports = function() {
     if (/-with-links/.test(lang)) {
       linksEnabled = true;
       lang = lang.replace(/-with-links/, "");
-    }
-
+    } 
     if (/-with-details/.test(lang)) {
       detailsEnabled = true;
       lang = lang.replace(/-with-details/, "");
@@ -146,10 +145,21 @@ function parseContent(data) {
 function parseAnchor(string) {
   var stripped = string.replace(/\[(.+)\]\(.+\)/gi, '$1').replace(/(<([^>]+)>)/ig, '');
   var clean = stripped.replace(/`/g, '');
+  var id = clean.replace(/[^\w]+/g, '-').toLowerCase();
+  if (id === '-') {
+    id = (function(string) {
+      var hash = 0;
+      for (var i = 0; i < string.length; i++) {
+        hash = (hash << 5) - hash + string.charCodeAt(i);
+        hash = hash & hash;
+      }
+      return Math.abs(hash);
+    })(clean);
+  }
 
   return {
     title: clean,
-    id: clean.replace(/[^\w]+/g, '-').toLowerCase()
+    id: id
   };
 }
 


### PR DESCRIPTION
최종 변환 결과가 `-` 한 글자인 경우 다국어 문자열 위주로 된 타이틀로
판단하고 이들 문자가 사라지기 직전 단계인 `clean` 변수를 기준으로
Java에서 기본으로 사용하는 해싱 알고리즘을 통해 정수 id를 생성한다.
이때 음수는 절댓값을 씌워 양수로 변환하는 추가 로직을 삽입하였다.